### PR TITLE
Removed printing of envelope and set abortConnect to false for redis connection

### DIFF
--- a/filters/ServiceConnect.Filters.MessageDeduplication/ServiceConnect.Filters.MessageDeduplication/DeduplicationFilterSettings.cs
+++ b/filters/ServiceConnect.Filters.MessageDeduplication/ServiceConnect.Filters.MessageDeduplication/DeduplicationFilterSettings.cs
@@ -75,7 +75,7 @@ namespace ServiceConnect.Filters.MessageDeduplication
             ConnectionStringMongoDb = "mongodb://localhost";
             DatabaseNameMongoDb = "ServiceConnect-Filters-MessageDeduplication";
             CollectionNameMongoDb = "ProcessedMessages";
-            ConnectionStringRedis = "localhost";
+            ConnectionStringRedis = "localhost,abortConnect=false";
             DatabaseIndexRedis = 0;
         }
     }

--- a/filters/ServiceConnect.Filters.MessageDeduplication/ServiceConnect.Filters.MessageDeduplication/Filters/OutgoingFilter.cs
+++ b/filters/ServiceConnect.Filters.MessageDeduplication/ServiceConnect.Filters.MessageDeduplication/Filters/OutgoingFilter.cs
@@ -73,8 +73,7 @@ namespace ServiceConnect.Filters.MessageDeduplication.Filters
             }
             catch (Exception ex)
             {
-                Logger.ErrorFormat("envelope: {0}", Newtonsoft.Json.JsonConvert.SerializeObject(envelope));
-                Logger.Error("Error processing outgoing deduplication filter ", ex);
+                Logger.Warn("Error processing outgoing deduplication filter ", ex);
             }
 
             return true;


### PR DESCRIPTION
- Removed printing of envelope to avoid logging headers such as security token.

- Set abortConnect to false for redis connections so it will silently reconnect in becakground instead of throwing an exception (https://stackoverflow.com/a/28821220 & https://stackoverflow.com/a/30918632)
